### PR TITLE
fix : api response 처리 로직 수정

### DIFF
--- a/core/presentation/src/main/java/com/dd2d/core/presentation/list/RefreshLazyListManager.kt
+++ b/core/presentation/src/main/java/com/dd2d/core/presentation/list/RefreshLazyListManager.kt
@@ -1,6 +1,10 @@
 package com.dd2d.core.presentation.list
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.dd2d.core.core.model.Pagination
 import com.dd2d.core.core.state.DataState
 import kotlinx.coroutines.CoroutineScope
@@ -11,6 +15,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 
+@Suppress("MemberVisibilityCanBePrivate")
 class RefreshLazyListManager <ListOptions, ListItemModel>(
     initialState: RefreshLazyListState = RefreshLazyListState.Success,
     initialListOption: ListOptions,
@@ -25,9 +30,12 @@ class RefreshLazyListManager <ListOptions, ListItemModel>(
         private set
 
     val list = mutableStateListOf<ListItemModel>()
-    val isLastPage = MutableStateFlow(false)
-    val totalItem = MutableStateFlow(0)
-    val totalPage = MutableStateFlow(0)
+    var isLastPage by mutableStateOf(false)
+        private set
+    var totalItem by mutableIntStateOf(0)
+        private set
+    var totalPage by mutableIntStateOf(0)
+        private set
 
     private fun getList(
         options: ListOptions,
@@ -48,9 +56,9 @@ class RefreshLazyListManager <ListOptions, ListItemModel>(
 
                         with(state.data) {
                             this@RefreshLazyListManager.list.addAll(this.list)
-                            this@RefreshLazyListManager.isLastPage.value = this.currentPage == this.totalPage
-                            this@RefreshLazyListManager.totalPage.value = this.totalPage
-                            this@RefreshLazyListManager.totalItem.value = this.totalItemCount
+                            this@RefreshLazyListManager.isLastPage = this.currentPage == this.totalPage
+                            this@RefreshLazyListManager.totalPage = this.totalPage
+                            this@RefreshLazyListManager.totalItem = this.totalItemCount
                         }
 
                         this@RefreshLazyListManager.options = options
@@ -66,7 +74,7 @@ class RefreshLazyListManager <ListOptions, ListItemModel>(
     }
 
     fun loadMore(options: ListOptions) {
-        if(isLastPage.value) return
+        if(isLastPage) return
         getList(options = options, isRefresh = false)
     }
 

--- a/data-source/remote/server/src/main/java/com/dd2d/data_source/remote/server/_common/ResponseMapper.kt
+++ b/data-source/remote/server/src/main/java/com/dd2d/data_source/remote/server/_common/ResponseMapper.kt
@@ -1,0 +1,12 @@
+package com.dd2d.data_source.remote.server._common
+
+import com.dd2d.core.core.model.Pagination
+
+fun <DTO, Model> PagingResponseDto<DTO>.toPagination(requestPage: Int, mapper: (DTO) -> Model): Pagination<Model> {
+    return Pagination(
+        list = this.dtoList.map(mapper),
+        currentPage = requestPage + 1,
+        totalPage = this.totalPage,
+        totalItemCount = -1,
+    )
+}

--- a/data-source/remote/server/src/main/java/com/dd2d/data_source/remote/server/code_post/CodePostApi.kt
+++ b/data-source/remote/server/src/main/java/com/dd2d/data_source/remote/server/code_post/CodePostApi.kt
@@ -14,7 +14,6 @@ import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
-import io.ktor.http.parameters
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -29,10 +28,10 @@ class CodePostApi @Inject constructor(
     ): PagingResponseDto<CodePostListItemResponseDto> = client
         .get("/v1/api/post/code/list") {
             authorizationHeader(tokenManager.getAccessToken())
-            parameters {
-                append("page", "$page")
-                append("size", "$size")
-                sort?.let { append("sort", sort) }
+            url {
+                parameters.append("page", "$page")
+                parameters.append("size", "$size")
+                sort?.let { parameters.append("sort", sort) }
             }
         }
         .bodyHandling()
@@ -45,11 +44,11 @@ class CodePostApi @Inject constructor(
     ): PagingResponseDto<CodePostListItemResponseDto> = client
         .get("/v1/api/post/code/search") {
             authorizationHeader(tokenManager.getAccessToken())
-            parameters {
-                append("search", search)
-                append("page", "$page")
-                append("size", "$size")
-                sort?.let { append("sort", sort) }
+            url {
+                parameters.append("search", search)
+                parameters.append("page", "$page")
+                parameters.append("size", "$size")
+                sort?.let { parameters.append("sort", sort) }
             }
         }
         .bodyHandling()
@@ -61,10 +60,10 @@ class CodePostApi @Inject constructor(
     ): PagingResponseDto<CodePostListItemResponseDto> = client
         .get("/v1/api/post/code/own") {
             authorizationHeader(tokenManager.getAccessToken())
-            parameters {
-                append("page", "$page")
-                append("size", "$size")
-                sort?.let { append("sort", sort) }
+            url {
+                    parameters.append("page", "$page")
+                    parameters.append("size", "$size")
+                    sort?.let { parameters.append("sort", sort) }
             }
         }
         .bodyHandling()
@@ -77,11 +76,11 @@ class CodePostApi @Inject constructor(
     ): PagingResponseDto<CodePostListItemResponseDto> = client
         .get("/v1/api/post/code/own/search") {
             authorizationHeader(tokenManager.getAccessToken())
-            parameters {
-                append("search", search)
-                append("page", "$page")
-                append("size", "$size")
-                sort?.let { append("sort", sort) }
+            url {
+                parameters.append("search", search)
+                parameters.append("page", "$page")
+                parameters.append("size", "$size")
+                sort?.let { parameters.append("sort", sort) }
             }
         }
         .bodyHandling()

--- a/data-source/remote/server/src/main/java/com/dd2d/data_source/remote/server/til/TILApi.kt
+++ b/data-source/remote/server/src/main/java/com/dd2d/data_source/remote/server/til/TILApi.kt
@@ -28,9 +28,9 @@ class TILApi @Inject constructor(
     ): PagingResponseDto<TILListItemResponseDto> = client
         .get(urlString = "/v1/api/post/til/list") {
             authorizationHeader(token = tokenManager.getAccessToken())
-            parameters {
-                append("page", page.toString())
-                append("size", size.toString())
+            url {
+                parameters.append("page", page.toString())
+                parameters.append("size", size.toString())
             }
         }
         .bodyHandling()
@@ -42,10 +42,10 @@ class TILApi @Inject constructor(
     ): PagingResponseDto<TILListItemResponseDto> = client
         .get(urlString = "/v1/api/post/til/search") {
             authorizationHeader(token = tokenManager.getAccessToken())
-            parameters {
-                append("page", page.toString())
-                append("size", size.toString())
-                append("search", search)
+            url {
+                parameters.append("page", page.toString())
+                parameters.append("size", size.toString())
+                parameters.append("search", search)
             }
         }.bodyHandling()
 
@@ -55,9 +55,9 @@ class TILApi @Inject constructor(
     ): PagingResponseDto<TILListItemResponseDto> = client
         .get(urlString = "/v1/api/post/til/own") {
             authorizationHeader(token = tokenManager.getAccessToken())
-            parameters {
-                append("page", page.toString())
-                append("size", size.toString())
+            url {
+                parameters.append("page", page.toString())
+                parameters.append("size", size.toString())
             }
         }
         .bodyHandling()
@@ -69,10 +69,10 @@ class TILApi @Inject constructor(
     ): PagingResponseDto<TILListItemResponseDto> = client
         .get(urlString = "/v1/api/post/til/own/search") {
             authorizationHeader(token = tokenManager.getAccessToken())
-            parameters {
-                append("page", page.toString())
-                append("size", size.toString())
-                append("search", search)
+            url {
+                parameters.append("page", page.toString())
+                parameters.append("size", size.toString())
+                parameters.append("search", search)
             }
         }.bodyHandling()
 

--- a/data/code-post/src/main/java/com/dd2d/data/code_post/repository/CodePostRepositoryImpl.kt
+++ b/data/code-post/src/main/java/com/dd2d/data/code_post/repository/CodePostRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.dd2d.data.code_post.mapper.toCodePost
 import com.dd2d.data.code_post.mapper.toCodePostListItem
 import com.dd2d.data.code_post.mapper.toCodePostUpdateRequestDto
 import com.dd2d.data.code_post.mapper.toCorePostCreateRequestDto
+import com.dd2d.data_source.remote.server._common.toPagination
 import com.dd2d.data_source.remote.server.code_post.CodePostApi
 import com.dd2d.data_source.remote.server.code_post.dto.response.CodePostListItemResponseDto
 import com.dd2d.domain.code_post.model.CodePost
@@ -28,11 +29,9 @@ class CodePostRepositoryImpl @Inject constructor(
             else codePostApi.getCodePostListBySearchKeyword(search = search, page = page, size = take, sort = sort)
         }
         emit(
-            Pagination(
-                list = response.dtoList.map(CodePostListItemResponseDto::toCodePostListItem),
-                currentPage = options.page,
-                totalPage = response.totalPage,
-                totalItemCount = -1,
+            response.toPagination(
+                requestPage = options.page,
+                mapper = CodePostListItemResponseDto::toCodePostListItem
             )
         )
     }.asDataState()
@@ -44,11 +43,9 @@ class CodePostRepositoryImpl @Inject constructor(
         }
 
         emit(
-            Pagination(
-                list = response.dtoList.map(CodePostListItemResponseDto::toCodePostListItem),
-                currentPage = options.page,
-                totalPage = response.totalPage,
-                totalItemCount = -1,
+            response.toPagination(
+                requestPage = options.page,
+                mapper = CodePostListItemResponseDto::toCodePostListItem
             )
         )
     }.asDataState()

--- a/data/til/src/main/java/com/dd2d/data/til/repository/TILRepositoryImpl.kt
+++ b/data/til/src/main/java/com/dd2d/data/til/repository/TILRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.dd2d.data.til.mapper.toTIL
 import com.dd2d.data.til.mapper.toTILCreateRequestDto
 import com.dd2d.data.til.mapper.toTILListItem
 import com.dd2d.data.til.mapper.toTILUpdateRequestDto
+import com.dd2d.data_source.remote.server._common.toPagination
 import com.dd2d.data_source.remote.server.til.TILApi
 import com.dd2d.data_source.remote.server.til.dto.response.TILListItemResponseDto
 import com.dd2d.domain.til.model.TIL
@@ -28,11 +29,9 @@ class TILRepositoryImpl @Inject constructor(
             else tilApi.getTILListBySearchKeyword(search = search, page = page, size = take)
         }
         emit(
-            Pagination(
-                list = response.dtoList.map(TILListItemResponseDto::toTILListItem),
-                currentPage = options.page,
-                totalPage = response.totalPage,
-                totalItemCount = -1,
+            response.toPagination(
+                requestPage = options.page,
+                mapper = TILListItemResponseDto::toTILListItem
             )
         )
     }.asDataState()
@@ -43,11 +42,9 @@ class TILRepositoryImpl @Inject constructor(
             else tilApi.getMyTILListBySearchKeyword(search = search, page = page, size = take)
         }
         emit(
-            Pagination(
-                list = response.dtoList.map(TILListItemResponseDto::toTILListItem),
-                currentPage = options.page,
-                totalPage = response.totalPage,
-                totalItemCount = -1,
+            response.toPagination(
+                requestPage = options.page,
+                mapper = TILListItemResponseDto::toTILListItem
             )
         )
     }.asDataState()

--- a/domain/code-post/src/main/java/com/dd2d/domain/code_post/model/CodePostListOptions.kt
+++ b/domain/code-post/src/main/java/com/dd2d/domain/code_post/model/CodePostListOptions.kt
@@ -1,7 +1,7 @@
 package com.dd2d.domain.code_post.model
 
 data class CodePostListOptions(
-    val page: Int = 1,
+    val page: Int = 0,
     val take: Int = 15,
     val sort: String? = null,
     val search: String = "",

--- a/presentation/code-post/src/main/java/com/dd2d/presentation/code_post/content/list/CodePostListViewModel.kt
+++ b/presentation/code-post/src/main/java/com/dd2d/presentation/code_post/content/list/CodePostListViewModel.kt
@@ -20,5 +20,5 @@ internal class CodePostListViewModel @Inject constructor(
     )
     fun onNextPage() = with(codePostListManager) { loadMore(options.copy(page = options.page + 1)) }
     fun onRefresh() = with(codePostListManager) { refresh(CodePostListOptions()) }
-    fun search(searchText: String) = with(codePostListManager) { refresh(options.copy(page = 1, search = searchText)) }
+    fun search(searchText: String) = with(codePostListManager) { refresh(CodePostListOptions(search = searchText)) }
 }

--- a/presentation/my/src/main/java/com/dd2d/presentation/my/conent/MyCodePostListContent.kt
+++ b/presentation/my/src/main/java/com/dd2d/presentation/my/conent/MyCodePostListContent.kt
@@ -49,7 +49,7 @@ internal fun MyCodePostListContent(
                 CodePostListItemComponent(
                     item = item,
                     onClick = { onItemClick(item.id) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth().animateItem()
                 )
                 HorizontalDivider()
             }

--- a/presentation/my/src/main/java/com/dd2d/presentation/my/screen/MyPageScreen.kt
+++ b/presentation/my/src/main/java/com/dd2d/presentation/my/screen/MyPageScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,6 +36,11 @@ fun MyPageScreen(
 
     var openFABMenu by remember { mutableStateOf(false) }
 
+    LaunchedEffect(key1 = Unit) {
+        viewModel.refreshCodePostList()
+        viewModel.refreshTILList()
+    }
+
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         floatingActionButton = {
@@ -43,6 +49,7 @@ fun MyPageScreen(
                 close = { openFABMenu = !openFABMenu },
                 options = listOf("CODE", "TIL"),
                 onOptionSelected = { index ->
+                    openFABMenu = false
                     when(index) {
                         0 -> navigationEvent(MyPageNavigator.CodePostCreate)
                         1 -> navigationEvent(MyPageNavigator.TILPostCreate)

--- a/presentation/my/src/main/java/com/dd2d/presentation/my/view_model/MyPageViewModel.kt
+++ b/presentation/my/src/main/java/com/dd2d/presentation/my/view_model/MyPageViewModel.kt
@@ -31,15 +31,17 @@ internal class MyPageViewModel @Inject constructor(
         initialListOption = CodePostListOptions(),
         scope = viewModelScope,
         flow = codePostRepository::getMyCodePostList,
+        lazyInit = true
     )
     fun nextCodePostPage() = with(codePostListManager) { loadMore(options = options.copy(page = options.page + 1)) }
-    fun refreshCodePostList() = with(codePostListManager) { refresh(options = options.copy(page = 1)) }
+    fun refreshCodePostList() = with(codePostListManager) { refresh(options = CodePostListOptions()) }
 
     val tilListManager = RefreshLazyListManager(
         initialListOption = TILListOptions(),
         scope = viewModelScope,
         flow = tilRepository::getMyTILList,
+        lazyInit = true
     )
     fun nextTILPage() = with(tilListManager) { loadMore(options = options.copy(page = options.page + 1)) }
-    fun refreshTILList() = with(tilListManager) { refresh(options = options.copy(page = 1)) }
+    fun refreshTILList() = with(tilListManager) { refresh(options = TILListOptions()) }
 }


### PR DESCRIPTION
 - request `url`에 `parameter` 추가 시 `url {}` 블럭 안에서 추가하도록 수정
 - 목록형 `response` 값을 Pagination 객체로 변환하는 로직을 `Response<DTO>.toPagination()` 함수를 통해 통일
 - 목록 요청 api 사용 시 기본 요청 `page` 값을 `0`으로 변경